### PR TITLE
Fix output variable syntax and numeric default

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -13,7 +13,7 @@ resource "aws_db_instance" "wpdb" {
   instance_class = "db.m4.large"
   allocated_storage = 50
   engine = "mysql"
-  name = "wordpress"
+  db_name = "wordpress"
   password = "${var.db_password}"
   username = "${var.db_user}"
   # If using Symphony, use 5.7.00, otherwise us AWS reccomended version 

--- a/output.tf
+++ b/output.tf
@@ -2,5 +2,5 @@
 #We just want the external DNS name of the load balancer 
 
 output "lb_address" {
-    value =  aws_lb.web-lb.dns_name
+  value = "${aws_lb.web-lb.dns_name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "web_number" {
-  type = number
-  default = "1"
+  type    = number
+  default = 1
 }
 #variable "web_number2" {}
 variable "web_ami" {


### PR DESCRIPTION
## Summary
- fix Terraform output syntax for lb address
- ensure web_number default is numeric
- fix RDS db_name argument

## Testing
- `terraform init -no-color`
- `terraform validate -no-color`

------
https://chatgpt.com/codex/tasks/task_e_68550ec8cf888320a7204f4a652e2ab1